### PR TITLE
Fix `Undefined index` error in saving new entry

### DIFF
--- a/services/ReverseRelationsService.php
+++ b/services/ReverseRelationsService.php
@@ -78,8 +78,10 @@ class ReverseRelationsService extends BaseApplicationComponent
     public function checkForAndDelete($element, $targetField, $newSourceIds, $elementType, $removeAll)
     {
         $oldSourceIds = array();
-        foreach ($this->oldSourceElements[$element->model->handle] as $oldSourceRelation) {
-            $oldSourceIds[] = $oldSourceRelation->id;
+        if (array_key_exists($element->model->handle, $this->oldSourceElements)) {
+            foreach ($this->oldSourceElements[$element->model->handle] as $oldSourceRelation) {
+                $oldSourceIds[] = $oldSourceRelation->id;
+            }
         }
 
         // If field was populated before


### PR DESCRIPTION
Hi Chase,

When I stored a new article, I became `Undefined index` error.
It seems to be caused by the fact that there is not a key in `$this->oldSourceElements`.

Therefore I wrote a modified code.
After confirmation, please merge it if you do not have any problem.

Thank you,
BUN